### PR TITLE
acquired initial bank params

### DIFF
--- a/database/consensus.go
+++ b/database/consensus.go
@@ -14,6 +14,9 @@ func (db *Db) GetLastBlock() (*dbtypes.BlockRow, error) {
 	stmt := `SELECT * FROM block ORDER BY height DESC LIMIT 1`
 
 	var blocks []dbtypes.BlockRow
+
+	time.Sleep(5 * time.Second)
+
 	if err := db.Sqlx.Select(&blocks, stmt); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The lag of 5s helps functions to get block info during periodic functions